### PR TITLE
Add Title 1 to parameters

### DIFF
--- a/RicohAddressBookManager.psm1
+++ b/RicohAddressBookManager.psm1
@@ -489,6 +489,7 @@ function Get-Entries {
                 UserCode  =      ( ForEach-Object { $_.item } | Where-Object { $_.propName -eq 'auth:name'    } ).propVal
                 Mail      =      ( ForEach-Object { $_.item } | Where-Object { $_.propName -eq 'mail:address' } ).propVal
                 FaxNumber =      ( ForEach-Object { $_.item } | Where-Object { $_.propName -eq 'fax:number'   } ).propVal
+                Title1     =      ( ForEach-Object { $_.item } | Where-Object { $_.propName -eq 'tagId'        } ).propVal
                 <#Folder    = New-Object -TypeName psobject -Property @{
                     Type      =      ( ForEach-Object { $_.item } | Where-Object { $_.propName -eq 'remoteFolder:type' } ).propVal
                     Server    =      ( ForEach-Object { $_.item } | Where-Object { $_.propName -eq 'remoteFolder:serverName' } ).propVal
@@ -544,6 +545,9 @@ function Get-Entries {
 
 .PARAMETER FaxNumber
     Fax Number of entry.
+    
+.PARAMETER Title1
+    Title 1 of entry - value of 1-11 corresponding to the list of values in the admin interface.
 
 .PARAMETER Hostname
     Hostname or IP Address of the copier to connect to.
@@ -592,6 +596,10 @@ function New-Entry {
         [ValidateNotNullOrEmpty()]
         [string]
         $FaxNumber,
+        
+        [ValidateNotNullOrEmpty()]
+        [string]
+        $Title1,
 
         [ValidatePattern('^\\\\|^ftp://')]
         [ValidateNotNullOrEmpty()]
@@ -801,7 +809,10 @@ function New-Entry {
             
         }
         
-        # creat the property count
+        # set the tagId value
+        $NewXml.Envelope.Body.putObjects.propListList.item.item[17].propVal = $Title1
+        
+        # create the property count
         $NewXml.Envelope.Body.putObjects.propListList.arrayType = "itt:string[][$($NewXml.Envelope.Body.putObjects.propListList.item.item.count)]"
 
         # build the webrequest

--- a/SoapTemplates/Get.xml
+++ b/SoapTemplates/Get.xml
@@ -13,6 +13,7 @@
 <item>longName</item>
 <item>auth:name</item>
 <item>mail:address</item>
+<item>tagId</item>
 <item>fax:number</item>
 <item>remoteFolder:type</item>
 <item>remoteFolder:serverName</item>

--- a/SoapTemplates/New.xml
+++ b/SoapTemplates/New.xml
@@ -75,6 +75,10 @@
 <propName>remoteFolder:passwordEncoding</propName>
 <propVal></propVal>
 </item>
+<item>
+<propName>tagId</propName>
+<propVal></propVal>
+</item>
 </item>
 </propListList>
 </m:putObjects>


### PR DESCRIPTION
This pull request adds Title 1 (tagId) to the available parameters. Useful if you want to separate entries on the main screen by letter.